### PR TITLE
緊急度 x 難易度ラベルの件数を出力するように修正

### DIFF
--- a/infra/usersupport/user_support_repository.go
+++ b/infra/usersupport/user_support_repository.go
@@ -37,3 +37,8 @@ func (r *userSupportRepository) GetUpdatedSupportIssues(since, until time.Time) 
 func (r *userSupportRepository) GetCurrentOpenSupportIssues() ([]*github.Issue, error) {
 	return r.ghClient.ListRepoIssues("sataga", "issue-warehouse", "open", []string{"support"})
 }
+
+func (r *userSupportRepository) GetCurrentOpenAnyLabelsSupportIssues(labels []string) ([]*github.Issue, error) {
+	labels = append(labels, "support")
+	return r.ghClient.ListRepoIssues("sataga", "issue-warehouse", "open", labels)
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func main() {
 		if until, err = time.Parse("2006-01-02", *untilStr); err != nil {
 			log.Fatalf("could not parse: %s", *untilStr)
 		}
+		// 終日までのIssueをカウントするための下処理
+		until = until.AddDate(0, 0, 1)
+		until = until.Add(-time.Minute)
 		usStats, err := us.GetUserSupportStats(since, until)
 		if err != nil {
 			log.Fatalf("get user support stats: %s", err)


### PR DESCRIPTION
memo
---
必要なデータ分だけinterface経由で取得するのか、まとめて取得してifでカウントアップするのか、悩ましいと思いながらも後者で進めた

出力結果
---
```
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   update-domain-for-urgency-label 
-> % go run main.go us                                                                                                      00:18:49 - 01:28:47
UserSupportStats From: 2020-11-24 00:00:00 +0000 UTC, Until: 2020-12-01 23:59:00 +0000 UTC
項目, 情報
Openチケット数, 10
新規作成されたチケット数, 8
情報更新されたチケット数, 10
クローズしたチケット数, 0
緊急度:高 のチケット数, 6
かつ、難易度:高 のチケット数, 3
かつ、難易度:低 のチケット数, 3
緊急度:低 のチケット数, 4
かつ、難易度:高 のチケット数, 2
かつ、難易度:低 のチケット数, 2
[open]issue-1, 323d 21h
[open]issue-2, 323d 21h
[open]issue-7, 0d 0h
[open]issue-6, 0d 0h
[open]issue-4, 0d 0h
[open]issue-3, 0d 0h
[open]issue-10, 0d 0h
[open]issue-9, 0d 0h
[open]issue-8, 0d 0h
[open]issue-5 , 0d 0h
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   update-domain-for-urgency-label 
-> %    
```