### PR TITLE
Add method and refactoring code

### DIFF
--- a/domain/usersupport/user_support.go
+++ b/domain/usersupport/user_support.go
@@ -225,7 +225,6 @@ func (us *userSupport) GetMonthlyReportStats(since, until time.Time) (*monthlySt
 			} else {
 				totalTime = int(issue.UpdatedAt.Sub(*issue.CreatedAt).Hours())
 			}
-
 			switch {
 			case totalTime <= 2:
 				monthlyStats.summaryStats[startEnd].NumScoreA++
@@ -379,9 +378,9 @@ func (us *userSupport) GetAnalysisReportStats(since, until time.Time) (*analysis
 // GenReport generate analysis report
 func (as *analysisStats) GenAnalysisReport() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("期間,Title,起票日,クローズ日,ステータス,担当チーム,担当アサイン,緊急度,問い合わせ種別,コメント数,経過時間,Keywordラベル\n"))
+	sb.WriteString(fmt.Sprintf("期間,Title,起票日,クローズ日,ステータス,担当チーム,担当アサイン,緊急度,問い合わせ種別,コメント数,経過時間,Keywordラベル,URL\n"))
 	for _, d := range as.detailStats {
-		sb.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s \n", d.TargetSpan, d.Title, d.CreatedAt, d.ClosedAt, d.State, d.TeamName, d.Assignee, d.Urgency, d.Genre, d.NumComments, d.OpenDuration, d.Labels))
+		sb.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s,%s \n", d.TargetSpan, d.Title, d.CreatedAt, d.ClosedAt, d.State, d.TeamName, d.Assignee, d.Urgency, d.Genre, d.NumComments, d.OpenDuration, d.Labels, d.HTMLURL))
 	}
 	return sb.String()
 }

--- a/domain/usersupport/user_support.go
+++ b/domain/usersupport/user_support.go
@@ -18,6 +18,8 @@ var (
 type UserSupport interface {
 	GetDailyReportStats(until time.Time) (*dailyStats, error)
 	GetMonthlyReportStats(since, until time.Time) (*monthlyStats, error)
+	GetAnalysisReportStats(since, until time.Time) (*analysisStats, error)
+	MethodTest(since, until time.Time) (*analysisStats, error)
 	// GenMonthlyReport(data map[string]*monthlyStats) string
 }
 
@@ -49,6 +51,10 @@ type monthlyStats struct {
 	summaryStats map[string]*summaryStats `yaml:"summary_stats"`
 	detailStats  map[int]*detailStats     `yaml:"detail_stats"`
 }
+
+type analysisStats struct {
+	detailStats map[int]*detailStats `yaml:"detail_stats"`
+}
 type summaryStats struct {
 	Span                         string `yajl:"span"`
 	NumCreatedIssues             int    `yaml:"num_created_issues"`
@@ -74,6 +80,7 @@ type detailStats struct {
 	HTMLURL      string `yaml:"detail_stats_of_issue_url"`
 	CreatedAt    string `yaml:"detail_stats_of_created_at"`
 	ClosedAt     string `yaml:"detail_stats_of_closed_at"`
+	State        string `yaml:"detail_stats_of_state"`
 	TargetSpan   string `yaml:"detail_stats_of_target_span"`
 	TeamName     string `yaml:"detail_stats_of_team_name"`
 	Urgency      string `yaml:"detail_stats_of_urgency"`
@@ -94,6 +101,7 @@ func NewUserSupport(repo Repository) UserSupport {
 
 // GetDailryReport
 func (us *userSupport) GetDailyReportStats(until time.Time) (*dailyStats, error) {
+	startEnd := fmt.Sprintf("%s", until.Format("2006-01-02"))
 	opi, err := us.repo.GetCurrentOpenNotUpdatedSupportIssues(until)
 	if err != nil {
 		return nil, fmt.Errorf("get open issues : %s", err)
@@ -124,27 +132,7 @@ func (us *userSupport) GetDailyReportStats(until time.Time) (*dailyStats, error)
 			dailyStats.NumTeamBResponse++
 			dailyStats.detailStats[i].TeamName = "Team-B"
 		}
-
-		var totalTime int
-		if issue.State != nil && *issue.State == "closed" {
-			totalTime = int(issue.ClosedAt.Sub(*issue.CreatedAt).Hours())
-		} else {
-			totalTime = int(issue.UpdatedAt.Sub(*issue.CreatedAt).Hours())
-		}
-
-		var assigns []string
-		if issue.Assignees != nil {
-			for _, assign := range issue.Assignees {
-				assigns = append(assigns, "@"+*assign.Login)
-			}
-		}
-
-		dailyStats.detailStats[i].Title = *issue.Title
-		dailyStats.detailStats[i].HTMLURL = *issue.HTMLURL
-		dailyStats.detailStats[i].Assignee = strings.Join(assigns, ",")
-		dailyStats.detailStats[i].NumComments = *issue.Comments
-		dailyStats.detailStats[i].CreatedAt = issue.CreatedAt.In(jp).Format("2006-01-02")
-		dailyStats.detailStats[i].OpenDuration = totalTime
+		dailyStats.detailStats[i].writeDetailStats(issue, startEnd)
 	}
 	return dailyStats, nil
 }
@@ -156,7 +144,7 @@ func (s *dailyStats) GetDailyReportStats() string {
 	sb.WriteString(fmt.Sprintf("総未更新チケット数, %d\n", s.NumNotUpdatedIssues))
 	sb.WriteString(fmt.Sprintf("Team-A 未更新チケット数, %d\n", s.NumTeamAResponse))
 	sb.WriteString(fmt.Sprintf("Team-B 未更新チケット数, %d\n", s.NumTeamBResponse))
-	sb.WriteString(fmt.Sprintf("=== 詳細((チケットリンク/Openからの経過時間)) ===\n"))
+	sb.WriteString(fmt.Sprintf("=== 詳細 ===\n"))
 	for _, issue := range s.detailStats {
 		dates := issue.OpenDuration / 24
 		hours := issue.OpenDuration % 24
@@ -172,8 +160,6 @@ func (s *dailyStats) GetDailyReportStats() string {
 func (us *userSupport) GetMonthlyReportStats(since, until time.Time) (*monthlyStats, error) {
 	//
 	span := 4
-	// monthlyStats:= make(map[string]*monthlyStats, span)
-	// monthlyStats := make(map[string]*summaryStats, span)
 	monthlyStats := &monthlyStats{
 		summaryStats: make(map[string]*summaryStats, span),
 		detailStats:  make(map[int]*detailStats, span),
@@ -205,42 +191,32 @@ func (us *userSupport) GetMonthlyReportStats(since, until time.Time) (*monthlySt
 			NumCreatedIssues: numCreated,
 		}
 		for _, issue := range cli {
-			monthlyStats.detailStats[cnt] = &detailStats{}
+			monthlyStats.detailStats[cnt] = &detailStats{
+				TeamAResolve: false,
+			}
 			if labelContains(issue.Labels, "genre:影響調査") {
 				monthlyStats.summaryStats[startEnd].NumGenreImpactSurveyIssues++
-				monthlyStats.detailStats[cnt].Genre = "影響調査"
 			}
 			if labelContains(issue.Labels, "genre:要望") {
 				monthlyStats.summaryStats[startEnd].NumGenreRequestIssues++
-				monthlyStats.detailStats[cnt].Genre = "要望"
 			}
 			if labelContains(issue.Labels, "genre:ログ調査") {
 				monthlyStats.summaryStats[startEnd].NumGenreLogSurveyIssues++
-				monthlyStats.detailStats[cnt].Genre = "ログ調査"
 			}
 			if labelContains(issue.Labels, "genre:仕様調査") {
 				monthlyStats.summaryStats[startEnd].NumGenreSpecSurveyIssues++
-				monthlyStats.detailStats[cnt].Genre = "仕様調査"
 			}
 			if labelContains(issue.Labels, "genre:障害調査") {
 				monthlyStats.summaryStats[startEnd].NumGenreIncidentSurveyIssues++
-				monthlyStats.detailStats[cnt].Genre = "障害調査"
 			}
 			if labelContains(issue.Labels, "TeamA単体解決") {
 				monthlyStats.summaryStats[startEnd].NumTeamAResolveIssues++
-				monthlyStats.detailStats[cnt].TeamAResolve = true
 			}
 			if labelContains(issue.Labels, "緊急度:高") || labelContains(issue.Labels, "緊急度:中") {
 				monthlyStats.summaryStats[startEnd].NumUrgencyHighIssues++
 			}
 			if labelContains(issue.Labels, "緊急度:低") {
 				monthlyStats.summaryStats[startEnd].NumUrgencyLowIssues++
-			}
-			if labelContains(issue.Labels, "Team-A") {
-				monthlyStats.detailStats[cnt].TeamName = "Team-A"
-			}
-			if labelContains(issue.Labels, "Team-B") {
-				monthlyStats.detailStats[cnt].TeamName = "Team-B"
 			}
 
 			var totalTime int
@@ -265,35 +241,7 @@ func (us *userSupport) GetMonthlyReportStats(since, until time.Time) (*monthlySt
 				monthlyStats.summaryStats[startEnd].NumScoreF++
 			}
 
-			monthlyStats.detailStats[cnt].Title = *issue.Title
-			monthlyStats.detailStats[cnt].HTMLURL = *issue.HTMLURL
-			monthlyStats.detailStats[cnt].NumComments = *issue.Comments
-			monthlyStats.detailStats[cnt].CreatedAt = issue.CreatedAt.In(jp).Format("2006-01-02")
-			monthlyStats.detailStats[cnt].ClosedAt = issue.ClosedAt.In(jp).Format("2006-01-02")
-			monthlyStats.detailStats[cnt].TargetSpan = startEnd
-
-			var assigns []string
-			if issue.Assignees != nil {
-				for _, assign := range issue.Assignees {
-					assigns = append(assigns, *assign.Login)
-				}
-			}
-			monthlyStats.detailStats[cnt].Assignee = strings.Join(assigns, ",")
-
-			var labels []string
-			if issue.Labels != nil {
-				for _, label := range issue.Labels {
-					if strings.Contains(*label.Name, "keyword") {
-						labels = append(labels, strings.Replace(*label.Name, "keyword:", "", -1))
-					}
-					if strings.Contains(*label.Name, "緊急度") {
-						monthlyStats.detailStats[cnt].Urgency = strings.Replace(*label.Name, "緊急度:", "", -1)
-					}
-				}
-			}
-			monthlyStats.detailStats[cnt].Labels = strings.Join(labels, ",")
-			monthlyStats.detailStats[cnt].OpenDuration = totalTime
-
+			monthlyStats.detailStats[cnt].writeDetailStats(issue, startEnd)
 			cnt++
 		}
 		monthlyStats.summaryStats[startEnd].NumClosedIssues = len(cli)
@@ -393,9 +341,115 @@ func (ms *monthlyStats) GenMonthlyReport() string {
 	for _, d := range ms.detailStats {
 		dates := d.OpenDuration / 24
 		hours := d.OpenDuration % 24
-		sb.WriteString(fmt.Sprintf("- [%s](%s),%s,%s,%s/%s,comment数:%d,経過時間:%dd%dh,解決フラグ:%t,span:%s\n", d.Title, d.HTMLURL, d.Urgency, d.Genre, d.TeamName, d.Assignee, d.NumComments, dates, hours, d.TeamAResolve, d.TargetSpan))
+		sb.WriteString(fmt.Sprintf("- [%s](%s),%s,%s,%s/%s,comment数:%d,経過時間:%dd%dh,解決フラグ:%t,span:	%s\n", d.Title, d.HTMLURL, d.Urgency, d.Genre, d.TeamName, d.Assignee, d.NumComments, dates, hours, d.TeamAResolve, d.TargetSpan))
 	}
 	return sb.String()
+}
+
+func (us *userSupport) GetAnalysisReportStats(since, until time.Time) (*analysisStats, error) {
+	span := 4
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	since = time.Date(since.Year(), since.Month(), 1, 0, 0, 0, 0, loc)
+
+	analysisStats := &analysisStats{
+		detailStats: make(map[int]*detailStats, span),
+	}
+
+	cnt := 0
+	for i := 1; i <= span; i++ {
+		startEnd := fmt.Sprintf("%s~%s", since.Format("2006-01-02"), until.Format("2006-01-02"))
+		upi, err := us.repo.GetUpdatedSupportIssues(since, until)
+		if err != nil {
+			return nil, fmt.Errorf("get open issues : %s", err)
+		}
+		for _, issue := range upi {
+			analysisStats.detailStats[cnt] = &detailStats{
+				TeamAResolve: false,
+			}
+			analysisStats.detailStats[cnt].writeDetailStats(issue, startEnd)
+			cnt++
+		}
+		since = time.Date(since.Year(), since.Month()-1, 1, 0, 0, 0, 0, loc)
+		until = since.AddDate(0, +1, -1)
+	}
+
+	return analysisStats, nil
+}
+
+// GenReport generate analysis report
+func (as *analysisStats) GenAnalysisReport() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("期間,Title,起票日,クローズ日,ステータス,担当チーム,担当アサイン,緊急度,問い合わせ種別,コメント数,経過時間,Keywordラベル\n"))
+	for _, d := range as.detailStats {
+		sb.WriteString(fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s \n", d.TargetSpan, d.Title, d.CreatedAt, d.ClosedAt, d.State, d.TeamName, d.Assignee, d.Urgency, d.Genre, d.NumComments, d.OpenDuration, d.Labels))
+	}
+	return sb.String()
+}
+
+func (us *userSupport) MethodTest(since, until time.Time) (*analysisStats, error) {
+	startEnd := fmt.Sprintf("%s~%s", since.Format("2006-01-02"), until.Format("2006-01-02"))
+	cli, err := us.repo.GetUpdatedSupportIssues(since, until)
+	if err != nil {
+		return nil, fmt.Errorf("get updated issues : %s", err)
+	}
+	analysisStats := &analysisStats{
+		detailStats: make(map[int]*detailStats, len(cli)),
+	}
+	for i, issue := range cli {
+		analysisStats.detailStats[i] = &detailStats{
+			TeamAResolve: false,
+		}
+		analysisStats.detailStats[i].writeDetailStats(issue, startEnd)
+	}
+	return analysisStats, nil
+}
+
+func (ds *detailStats) writeDetailStats(issue *github.Issue, startEnd string) {
+	var labels []string
+	if issue.Labels != nil {
+		for _, label := range issue.Labels {
+			if strings.Contains(*label.Name, "keyword") {
+				labels = append(labels, strings.Replace(*label.Name, "keyword:", "", -1))
+			}
+			if strings.Contains(*label.Name, "緊急度") {
+				ds.Urgency = strings.Replace(*label.Name, "緊急度:", "", -1)
+			}
+			if strings.Contains(*label.Name, "Team-") {
+				ds.TeamName = *label.Name
+			}
+			if strings.Contains(*label.Name, "単体解決") {
+				ds.TeamAResolve = true
+			}
+			if strings.Contains(*label.Name, "genre") {
+				ds.Genre = strings.Replace(*label.Name, "genre:", "", -1)
+			}
+		}
+	}
+	var assigns []string
+	if issue.Assignees != nil {
+		for _, assign := range issue.Assignees {
+			assigns = append(assigns, *assign.Login)
+		}
+	}
+
+	var totalTime int
+	if issue.State != nil && *issue.State == "closed" {
+		totalTime = int(issue.ClosedAt.Sub(*issue.CreatedAt).Hours())
+		ds.ClosedAt = issue.ClosedAt.In(jp).Format("2006-01-02")
+	} else {
+		totalTime = int(issue.UpdatedAt.Sub(*issue.CreatedAt).Hours())
+	}
+
+	ds.Assignee = strings.Join(assigns, " ")
+	ds.Title = *issue.Title
+	ds.HTMLURL = *issue.HTMLURL
+	ds.NumComments = *issue.Comments
+	ds.State = *issue.State
+	ds.CreatedAt = issue.CreatedAt.In(jp).Format("2006-01-02")
+	ds.OpenDuration = totalTime
+	ds.Assignee = strings.Join(assigns, " ")
+	ds.Labels = strings.Join(labels, " ")
+	ds.TargetSpan = startEnd
 }
 
 //配列の中に特定の文字列が含まれるかを返す

--- a/infra/usersupport/user_support_repository.go
+++ b/infra/usersupport/user_support_repository.go
@@ -27,7 +27,7 @@ func (r *userSupportRepository) GetUpdatedSupportIssues(since, until time.Time) 
 	}
 	iss := make([]*github.Issue, 0, len(issues))
 	for _, is := range issues {
-		if is.UpdatedAt.Before(until) {
+		if is.UpdatedAt.After(since) && is.UpdatedAt.Before(until) {
 			iss = append(iss, is)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -87,6 +87,26 @@ func main() {
 			log.Fatalf("get user support stats: %s", err)
 		}
 		fmt.Printf("%s", monthlyStats.GenMonthlyReport())
+	case "analysis-report":
+		if err := userSupportFlag.Parse(subCommandArgs[1:]); err != nil {
+			log.Fatalf("parsing user support flag: %s", err)
+		}
+		usrepo := ius.NewUserSupportRepository(ghcli)
+		us := dus.NewUserSupport(usrepo)
+		var since, until time.Time
+		var err error
+		if since, err = time.Parse("2006-01-02", *sinceStr); err != nil {
+			log.Fatalf("could not parse: %s", *sinceStr)
+		}
+		if until, err = time.Parse("2006-01-02", *untilStr); err != nil {
+			log.Fatalf("could not parse: %s", *untilStr)
+		}
+		fmt.Printf("Reporting Stats From: %s, Until: %s\n", since, until)
+		analysisStats, err := us.GetAnalysisReportStats(since, until)
+		if err != nil {
+			log.Fatalf("get user support stats: %s", err)
+		}
+		fmt.Printf("%s", analysisStats.GenAnalysisReport())
 	case "slacktest":
 		channel := "times_t-sataga"
 		username := "t-sataga"
@@ -95,5 +115,26 @@ func main() {
 		if err != nil {
 			log.Fatalf("slack post message failed: %s", err)
 		}
+	case "methodtest":
+		if err := userSupportFlag.Parse(subCommandArgs[1:]); err != nil {
+			log.Fatalf("parsing user support flag: %s", err)
+		}
+		usrepo := ius.NewUserSupportRepository(ghcli)
+		us := dus.NewUserSupport(usrepo)
+		var since, until time.Time
+		var err error
+		if since, err = time.Parse("2006-01-02", *sinceStr); err != nil {
+			log.Fatalf("could not parse: %s", *sinceStr)
+		}
+		if until, err = time.Parse("2006-01-02", *untilStr); err != nil {
+			log.Fatalf("could not parse: %s", *untilStr)
+		}
+		fmt.Printf("Reporting Stats From: %s, Until: %s\n", since, until)
+		testStats, err := us.MethodTest(since, until)
+		if err != nil {
+			log.Fatalf("get user support stats: %s", err)
+		}
+		fmt.Printf("%s", testStats)
 	}
+
 }

--- a/main.go
+++ b/main.go
@@ -60,7 +60,6 @@ func main() {
 		if err != nil {
 			log.Fatalf("get user support stats: %s", err)
 		}
-		fmt.Printf("dailyReportStats Until: %s\n", until)
 		fmt.Printf("%s", dairyStats.GetDailyReportStats())
 		// channel := "times_t-sataga"
 		// username := "t-sataga"
@@ -134,7 +133,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("get user support stats: %s", err)
 		}
-		fmt.Printf("%s", testStats)
+		fmt.Printf("%v", testStats)
 	}
 
 }


### PR DESCRIPTION
実行ログ
---
```
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Add-method-for-analysis-report ± 
-> % go run main.go analysis-report                                                                                                                                                                               22:30:55 - 02:08:35
Reporting Stats From: 2020-12-27 00:00:00 +0000 UTC, Until: 2021-01-03 00:00:00 +0000 UTC
期間,Title,起票日,クローズ日,ステータス,担当チーム,担当アサイン,緊急度,問い合わせ種別,コメント数,経過時間,Keywordラベル
2020-12-01~2021-01-03,issue-5,2020-12-01,,open,Team-A,sataga,中,影響調査,1,454,Kubernetes 
2020-12-01~2021-01-03,issue-3,2020-11-29,2020-12-20,closed,Team-A,,中,障害調査,0,483,Kubernetes 
2020-12-01~2021-01-03,issue-2,2020-01-10,2020-12-27,closed,Team-B,sataga,高,ログ調査,2,8425,Openstack 
2020-12-01~2021-01-03,issue-1,2020-01-10,2020-12-27,closed,Team-A,sataga,低,要望,4,8425,Openstack 
2020-12-01~2021-01-03,issue-11,2020-12-30,,open,Team-B,,高,障害調査,0,57,Kubernetes Network 
2020-12-01~2021-01-03,issue-10,2020-12-01,2020-12-20,closed,Team-A,,高,要望,1,455,Network 
2020-12-01~2021-01-03,issue-9,2020-12-01,,open,Team-A,,高,要望,1,454,Network 
2020-12-01~2021-01-03,issue-8,2020-12-01,,open,Team-A,,中,ログ調査,0,454,Openstack 
2020-12-01~2021-01-03,issue-7,2020-12-01,,open,Team-A,,低,要望,1,454,Openstack 
2020-12-01~2021-01-03,issue-6,2020-12-01,,open,Team-A,,低,影響調査,0,454,Network 
2020-12-01~2021-01-03,issue-4,2020-11-29,2020-12-20,closed,Team-A,,低,仕様調査,1,483,Network 

 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Add-method-for-analysis-report ± 
-> % go run main.go daily-report                                                                                                                                                                                  02:08:40 - 02:08:45
dailyReportStats Until: 2020-12-27 02:08:47.469922 +0900 JST m=-604799.997999671
=== サマリー ===
総未更新チケット数, 5
Team-A 未更新チケット数, 5
Team-B 未更新チケット数, 0
=== 詳細((チケットリンク/Openからの経過時間)) ===
- <https://github.com/sataga/issue-warehouse/issues/9|issue-9> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/8|issue-8> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/7|issue-7> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/6|issue-6> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/5|issue-5> 18d22h Team-A/sataga

 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Add-method-for-analysis-report ± 
-> % go run main.go monthly-report                                                                                                                                                                                02:08:48 - 02:08:54
## サマリー 
|項目|2020-12-06~2020-12-13|2020-12-13~2020-12-20|2020-12-20~2020-12-27|2020-12-27~2021-01-03|
|----|----|----|----|----|
|起票件数|0|0|0|1|
|Team-A完結件数|0|1|0|0|
|クローズ件数|0|3|2|0|
|Team-A完結率(％)|0|33.3|0|0|
|ジャンル:要望件数|0|1|1|0|
|ジャンル:ログ調査件数|0|0|1|0|
|ジャンル:影響調査件数|0|0|1|0|
|ジャンル:仕様調査件数|0|1|0|0|
|ジャンル:障害調査件数|0|1|0|0|
|スコアA|0|0|0|0|
|スコアB|0|0|0|0|
|スコアC|0|0|0|0|
|スコアD|0|0|0|0|
|スコアE|0|0|0|0|
|スコアF|0|3|2|0|

## 詳細 
- [issue-2](https://github.com/sataga/issue-warehouse/issues/2),高,ログ調査,Team-B/sataga,comment数:2,経過時間:351d1h,解決フラグ:false,span:    2020-12-20~2020-12-27
- [issue-1](https://github.com/sataga/issue-warehouse/issues/1),低,要望,Team-A/sataga,comment数:4,経過時間:351d1h,解決フラグ:false,span:        2020-12-20~2020-12-27
- [issue-10](https://github.com/sataga/issue-warehouse/issues/10),高,要望,Team-A/,comment数:1,経過時間:18d23h,解決フラグ:true,span:     2020-12-13~2020-12-20
- [issue-4](https://github.com/sataga/issue-warehouse/issues/4),低,仕様調査,Team-A/,comment数:1,経過時間:20d3h,解決フラグ:false,span:   2020-12-13~2020-12-20
- [issue-3](https://github.com/sataga/issue-warehouse/issues/3),中,障害調査,Team-A/,comment数:0,経過時間:20d3h,解決フラグ:false,span:   2020-12-13~2020-12-20

 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Add-method-for-analysis-report ± 
-> % go run main.go daily-report                                                                                                                                                                                  02:09:11 - 02:09:33
dailyReportStats Until: 2020-12-27 02:09:35.224668 +0900 JST m=-604799.998379266
=== サマリー ===
総未更新チケット数, 5
Team-A 未更新チケット数, 5
Team-B 未更新チケット数, 0
=== 詳細 ===
- <https://github.com/sataga/issue-warehouse/issues/9|issue-9> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/8|issue-8> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/7|issue-7> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/6|issue-6> 18d22h Team-A/
- <https://github.com/sataga/issue-warehouse/issues/5|issue-5> 18d22h Team-A/sataga
```