### PR TITLE
コメント、イベント情報で何が取れるのかを確認する

### DIFF
--- a/domain/usersupport/user_support.go
+++ b/domain/usersupport/user_support.go
@@ -37,6 +37,8 @@ type Repository interface {
 	GetCurrentOpenSupportIssues() ([]*github.Issue, error)
 	GetCreatedSupportIssues(since, until time.Time) ([]*github.Issue, error)
 	GetLabelsByQuery(query string) ([]*github.LabelResult, error)
+	GetComments(number int) []*github.IssueComment
+	GetEvents(number int) []*github.IssueEvent
 }
 
 type userSupport struct {
@@ -289,6 +291,20 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 			}
 
 			LongTermStats.DetailStats[cnt].writeDetailStats(issue, startEnd)
+			comments := us.repo.GetComments(*issue.Number)
+			fmt.Printf("title:%s\n", *issue.Title)
+			for _, comment := range comments {
+				fmt.Println(*comment.Body)
+			}
+			events := us.repo.GetEvents(*issue.Number)
+			for i, event := range events {
+				fmt.Println(i)
+				fmt.Println(*event.Event)
+				if *event.Event == "moved_columns_in_project" {
+					fmt.Println(i)
+				}
+			}
+
 			cnt++
 		}
 		LongTermStats.SummaryStats[startEnd].NumClosedIssues = len(cli)
@@ -298,7 +314,6 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 			tmpTotal := (LongTermStats.SummaryStats[startEnd].NumScoreA * 1) + (LongTermStats.SummaryStats[startEnd].NumScoreB * 2) + (LongTermStats.SummaryStats[startEnd].NumScoreC * 3) + (LongTermStats.SummaryStats[startEnd].NumScoreD * 4) + (LongTermStats.SummaryStats[startEnd].NumScoreE * 5) + (LongTermStats.SummaryStats[startEnd].NumScoreF * 6)
 			LongTermStats.SummaryStats[startEnd].NumTotalScore = float64(tmpTotal) / float64(LongTermStats.SummaryStats[startEnd].NumClosedIssues)
 		}
-
 		switch kind {
 		case "weekly-report":
 			since = since.AddDate(0, 0, -7)

--- a/infra/github/github.go
+++ b/infra/github/github.go
@@ -26,6 +26,8 @@ type Client interface {
 	PullRequest(owner, repo, title, head, body, baseBranch string) (string, error)
 	ListRepoIssuesSince(owner, repo string, since time.Time, state string, labels []string) ([]*github.Issue, error)
 	ListRepoIssues(owner, repo string, state string, labels []string) ([]*github.Issue, error)
+	ListComments(owner, repo string, number int) ([]*github.IssueComment, *github.Response, error)
+	ListIssueEvent(owner, repo string, number int) ([]*github.IssueEvent, *github.Response, error)
 	GetRepoID(owner, repo string) (int64, error)
 	SearchLabelsByQuery(repoID int64, query string) ([]*github.LabelResult, error)
 	SearchIssuesByQuery(query string) ([]github.Issue, error)
@@ -175,6 +177,24 @@ func (c *ghclient) ListRepoIssues(owner, repo string, state string, labels []str
 				PerPage: 30,
 			},
 		})
+	})
+}
+
+// func (c *ghclient) ListComments(owner, repo string, number int) ([]*github.IssueComment, error) {
+func (c *ghclient) ListComments(owner, repo string, number int) ([]*github.IssueComment, *github.Response, error) {
+	return c.client.Issues.ListComments(c.ctx, owner, repo, number, &github.IssueListCommentsOptions{
+		ListOptions: github.ListOptions{
+			Page:    1,
+			PerPage: 30,
+		},
+	})
+
+}
+
+func (c *ghclient) ListIssueEvent(owner, repo string, number int) ([]*github.IssueEvent, *github.Response, error) {
+	return c.client.Issues.ListIssueEvents(c.ctx, owner, repo, number, &github.ListOptions{
+		Page:    1,
+		PerPage: 30,
 	})
 }
 

--- a/infra/usersupport/user_support_repository.go
+++ b/infra/usersupport/user_support_repository.go
@@ -91,3 +91,13 @@ func (r *userSupportRepository) GetLabelsByQuery(query string) ([]*github.LabelR
 	repoID, _ := r.ghClient.GetRepoID("sataga", "issue-warehouse")
 	return r.ghClient.SearchLabelsByQuery(repoID, query)
 }
+
+func (r *userSupportRepository) GetComments(number int) []*github.IssueComment {
+	comments, _, _ := r.ghClient.ListComments("sataga", "issue-warehouse", number)
+	return comments
+}
+
+func (r *userSupportRepository) GetEvents(number int) []*github.IssueEvent {
+	events, _, _ := r.ghClient.ListIssueEvent("sataga", "issue-warehouse", number)
+	return events
+}


### PR DESCRIPTION
わかったこと
---
- カンバンボードの移動したタイミングがわかってもどこからどこへが入っていないため時間換算はできなさそう
- やるとしたらコメントに規則を設けていくこと

確認まとめ
---
- https://github.com/sataga/issue-warehouse/issues/6
```
API server listening at: 127.0.0.1:46101
title:INC0000006 - Sample Issue
着手
to user
from user
クローズ処理
0
labeled
1
labeled
2
labeled
3
labeled
4
labeled
5
labeled
6
unlabeled
7
renamed
8
added_to_project
9
moved_columns_in_project
```
ブレークアウトしてのスクショ
![image](https://user-images.githubusercontent.com/24913906/109425717-0622e800-7a2d-11eb-90f6-b88b40197c28.png)