### PR TITLE
longterm-report メソッドのテスト実装(微修正込み)

### DIFF
--- a/domain/usersupport/user_support.go
+++ b/domain/usersupport/user_support.go
@@ -22,7 +22,7 @@ var (
 // UserSupport is interface for getting user support info
 type UserSupport interface {
 	GetDailyReportStats(now time.Time, dayAgo int) (*DailyStats, error)
-	GetLongTermReportStats(until time.Time, kind string, span int) (*LongTermStats, error)
+	GetLongTermReportStats(since, until time.Time) (*LongTermStats, error)
 	GetAnalysisReportStats(since, until time.Time, state string, span int) (*AnalysisStats, error)
 	GetKeywordReportStats(until time.Time, kind string, span int) (*KeywordStats, error)
 	MethodTest(since, until time.Time) (*AnalysisStats, error)
@@ -105,7 +105,6 @@ type DetailStats struct {
 	TargetSpan   string `yaml:"detail_stats_of_target_span"`
 	TeamName     string `yaml:"detail_stats_of_team_name"`
 	Urgency      string `yaml:"detail_stats_of_urgency"`
-	TeamAResolve bool   `yaml:"detail_stats_of_team_a_resolve"`
 	Genre        string `yaml:"detail_stats_of_genre"`
 	Labels       string `yaml:"detail_stats_of_labels"`
 	Assignee     string `yaml:"detail_stats_of_assign"`
@@ -192,112 +191,92 @@ func (ds *DailyStats) GetDailyReportStats() string {
 	return sb.String()
 }
 
-func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span int) (*LongTermStats, error) {
-	var since time.Time
-	loc, _ := time.LoadLocation("Asia/Tokyo")
-	switch kind {
-	case "weekly":
-		since = until.AddDate(0, 0, -7)
-	case "monthly":
-		since = time.Date(until.Year(), until.Month(), 1, 0, 0, 0, 0, loc)
-		until = since.AddDate(0, +1, -1)
-	}
+func (us *userSupport) GetLongTermReportStats(since, until time.Time) (*LongTermStats, error) {
 
 	LongTermStats := &LongTermStats{
-		SummaryStats: make(map[string]*SummaryStats, span),
-		DetailStats:  make(map[int]*DetailStats, span),
+		SummaryStats: make(map[string]*SummaryStats),
+		DetailStats:  make(map[int]*DetailStats),
 	}
 	cnt := 0
-	for i := 1; i <= span; i++ {
-		startEnd := fmt.Sprintf("%s~%s", since.Format("2006-01-02"), until.Format("2006-01-02"))
-		cri, err := us.repo.GetCreatedSupportIssues(since, until)
-		if err != nil {
-			return nil, fmt.Errorf("get open issues : %s", err)
-		}
+	startEnd := fmt.Sprintf("%s~%s", since.Format("2006-01-02"), until.Format("2006-01-02"))
+	cri, err := us.repo.GetCreatedSupportIssues(since, until)
+	if err != nil {
+		return nil, fmt.Errorf("get open issues : %s", err)
+	}
 
-		cli, err := us.repo.GetClosedSupportIssues(since, until)
-		if err != nil {
-			return nil, fmt.Errorf("get updated issues : %s", err)
-		}
+	cli, err := us.repo.GetClosedSupportIssues(since, until)
+	if err != nil {
+		return nil, fmt.Errorf("get updated issues : %s", err)
+	}
 
-		LongTermStats.SummaryStats[startEnd] = &SummaryStats{
-			Span:             startEnd,
-			NumCreatedIssues: len(cri),
+	LongTermStats.SummaryStats[startEnd] = &SummaryStats{
+		Span:             startEnd,
+		NumCreatedIssues: len(cri),
+	}
+	for _, issue := range cli {
+		LongTermStats.DetailStats[cnt] = &DetailStats{
+			Escalation: false,
 		}
-		for _, issue := range cli {
-			LongTermStats.DetailStats[cnt] = &DetailStats{
-				TeamAResolve: false,
-			}
+		if labelContains(issue.Labels, "genre:通常問合せ") {
+			LongTermStats.SummaryStats[startEnd].NumGenreNormalIssues++
+		}
+		if labelContains(issue.Labels, "genre:要望") {
+			LongTermStats.SummaryStats[startEnd].NumGenreRequestIssues++
+		}
+		if labelContains(issue.Labels, "genre:サービス障害") {
+			LongTermStats.SummaryStats[startEnd].NumGenreFailureIssues++
+		}
+		if labelContains(issue.Labels, "Escalation") {
+			LongTermStats.SummaryStats[startEnd].NumEscalationAllIssues++
 			if labelContains(issue.Labels, "genre:通常問合せ") {
-				LongTermStats.SummaryStats[startEnd].NumGenreNormalIssues++
+				LongTermStats.SummaryStats[startEnd].NumEscalationNormalIssues++
 			}
 			if labelContains(issue.Labels, "genre:要望") {
-				LongTermStats.SummaryStats[startEnd].NumGenreRequestIssues++
+				LongTermStats.SummaryStats[startEnd].NumEscalationRequestIssues++
 			}
 			if labelContains(issue.Labels, "genre:サービス障害") {
-				LongTermStats.SummaryStats[startEnd].NumGenreFailureIssues++
+				LongTermStats.SummaryStats[startEnd].NumEscalationFailureIssues++
 			}
-			if labelContains(issue.Labels, "Escalation") {
-				LongTermStats.SummaryStats[startEnd].NumEscalationAllIssues++
-				if labelContains(issue.Labels, "genre:通常問合せ") {
-					LongTermStats.SummaryStats[startEnd].NumEscalationNormalIssues++
-				}
-				if labelContains(issue.Labels, "genre:要望") {
-					LongTermStats.SummaryStats[startEnd].NumEscalationRequestIssues++
-				}
-				if labelContains(issue.Labels, "genre:サービス障害") {
-					LongTermStats.SummaryStats[startEnd].NumEscalationFailureIssues++
-				}
-			}
-			if labelContains(issue.Labels, "緊急度：高") || labelContains(issue.Labels, "緊急度：中") {
-				LongTermStats.SummaryStats[startEnd].NumUrgencyHighIssues++
-			}
-			if labelContains(issue.Labels, "緊急度：低") {
-				LongTermStats.SummaryStats[startEnd].NumUrgencyLowIssues++
-			}
-
-			var totalTime int
-			if issue.State != nil && *issue.State == "closed" {
-				totalTime = int(issue.ClosedAt.Sub(*issue.CreatedAt).Hours())
-			} else {
-				totalTime = int(issue.UpdatedAt.Sub(*issue.CreatedAt).Hours())
-			}
-			switch {
-			case totalTime <= 2*24:
-				LongTermStats.SummaryStats[startEnd].NumScoreA++
-			case totalTime <= 5*24:
-				LongTermStats.SummaryStats[startEnd].NumScoreB++
-			case totalTime <= 10*24:
-				LongTermStats.SummaryStats[startEnd].NumScoreC++
-			case totalTime <= 20*24:
-				LongTermStats.SummaryStats[startEnd].NumScoreD++
-			case totalTime <= 30*24:
-				LongTermStats.SummaryStats[startEnd].NumScoreE++
-			default:
-				LongTermStats.SummaryStats[startEnd].NumScoreF++
-			}
-
-			LongTermStats.DetailStats[cnt].writeDetailStats(issue, startEnd)
-			cnt++
 		}
-		LongTermStats.SummaryStats[startEnd].NumClosedIssues = len(cli)
-		if LongTermStats.SummaryStats[startEnd].NumClosedIssues == 0 {
-			LongTermStats.SummaryStats[startEnd].NumTotalScore = 0
+		if labelContains(issue.Labels, "緊急度：高") || labelContains(issue.Labels, "緊急度：中") {
+			LongTermStats.SummaryStats[startEnd].NumUrgencyHighIssues++
+		}
+		if labelContains(issue.Labels, "緊急度：低") {
+			LongTermStats.SummaryStats[startEnd].NumUrgencyLowIssues++
+		}
+
+		var totalTime int
+		if issue.State != nil && *issue.State == "closed" {
+			totalTime = int(issue.ClosedAt.Sub(*issue.CreatedAt).Hours())
 		} else {
-			tmpTotal := (LongTermStats.SummaryStats[startEnd].NumScoreA * 1) + (LongTermStats.SummaryStats[startEnd].NumScoreB * 2) + (LongTermStats.SummaryStats[startEnd].NumScoreC * 3) + (LongTermStats.SummaryStats[startEnd].NumScoreD * 4) + (LongTermStats.SummaryStats[startEnd].NumScoreE * 5) + (LongTermStats.SummaryStats[startEnd].NumScoreF * 6)
-			LongTermStats.SummaryStats[startEnd].NumTotalScore = float64(tmpTotal) / float64(LongTermStats.SummaryStats[startEnd].NumClosedIssues)
+			totalTime = int(issue.UpdatedAt.Sub(*issue.CreatedAt).Hours())
+		}
+		switch {
+		case totalTime <= 2*24:
+			LongTermStats.SummaryStats[startEnd].NumScoreA++
+		case totalTime <= 5*24:
+			LongTermStats.SummaryStats[startEnd].NumScoreB++
+		case totalTime <= 10*24:
+			LongTermStats.SummaryStats[startEnd].NumScoreC++
+		case totalTime <= 20*24:
+			LongTermStats.SummaryStats[startEnd].NumScoreD++
+		case totalTime <= 30*24:
+			LongTermStats.SummaryStats[startEnd].NumScoreE++
+		default:
+			LongTermStats.SummaryStats[startEnd].NumScoreF++
 		}
 
-		switch kind {
-		case "weekly":
-			since = since.AddDate(0, 0, -7)
-			until = until.AddDate(0, 0, -7)
-		case "monthly":
-			since = time.Date(since.Year(), since.Month()-1, 1, 0, 0, 0, 0, loc)
-			until = since.AddDate(0, +1, -1)
-		}
-
+		LongTermStats.DetailStats[cnt].writeDetailStats(issue, startEnd)
+		cnt++
 	}
+	LongTermStats.SummaryStats[startEnd].NumClosedIssues = len(cli)
+	if LongTermStats.SummaryStats[startEnd].NumClosedIssues == 0 {
+		LongTermStats.SummaryStats[startEnd].NumTotalScore = 0
+	} else {
+		tmpTotal := (LongTermStats.SummaryStats[startEnd].NumScoreA * 1) + (LongTermStats.SummaryStats[startEnd].NumScoreB * 2) + (LongTermStats.SummaryStats[startEnd].NumScoreC * 3) + (LongTermStats.SummaryStats[startEnd].NumScoreD * 4) + (LongTermStats.SummaryStats[startEnd].NumScoreE * 5) + (LongTermStats.SummaryStats[startEnd].NumScoreF * 6)
+		LongTermStats.SummaryStats[startEnd].NumTotalScore = float64(tmpTotal) / float64(LongTermStats.SummaryStats[startEnd].NumClosedIssues)
+	}
+
 	return LongTermStats, nil
 }
 
@@ -647,7 +626,7 @@ func (us *userSupport) MethodTest(since, until time.Time) (*AnalysisStats, error
 	}
 	for i, issue := range cli {
 		AnalysisStats.DetailStats[i] = &DetailStats{
-			TeamAResolve: false,
+			Escalation: false,
 		}
 		AnalysisStats.DetailStats[i].writeDetailStats(issue, startEnd)
 	}
@@ -668,7 +647,7 @@ func (ds *DetailStats) writeDetailStats(issue *github.Issue, startEnd string) {
 				ds.TeamName = strings.Replace(*label.Name, " 対応中", "", -1)
 			}
 			if strings.Contains(*label.Name, "Escalation") {
-				ds.TeamAResolve = true
+				ds.Escalation = true
 			}
 			if strings.Contains(*label.Name, "genre") {
 				ds.Genre = strings.Replace(*label.Name, "genre:", "", -1)

--- a/domain/usersupport/user_support.go
+++ b/domain/usersupport/user_support.go
@@ -196,9 +196,9 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 	var since time.Time
 	loc, _ := time.LoadLocation("Asia/Tokyo")
 	switch kind {
-	case "weekly-report":
+	case "weekly":
 		since = until.AddDate(0, 0, -7)
-	case "monthly-report":
+	case "monthly":
 		since = time.Date(until.Year(), until.Month(), 1, 0, 0, 0, 0, loc)
 		until = since.AddDate(0, +1, -1)
 	}
@@ -214,16 +214,6 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 		if err != nil {
 			return nil, fmt.Errorf("get open issues : %s", err)
 		}
-		upi, err := us.repo.GetUpdatedSupportIssues(since, until)
-		if err != nil {
-			return nil, fmt.Errorf("get open issues : %s", err)
-		}
-		numClosed := 0
-		for _, issue := range upi {
-			if issue.State != nil && *issue.State == "closed" {
-				numClosed++
-			}
-		}
 
 		cli, err := us.repo.GetClosedSupportIssues(since, until)
 		if err != nil {
@@ -232,7 +222,6 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 
 		LongTermStats.SummaryStats[startEnd] = &SummaryStats{
 			Span:             startEnd,
-			NumClosedIssues:  numClosed,
 			NumCreatedIssues: len(cri),
 		}
 		for _, issue := range cli {
@@ -300,10 +289,10 @@ func (us *userSupport) GetLongTermReportStats(until time.Time, kind string, span
 		}
 
 		switch kind {
-		case "weekly-report":
+		case "weekly":
 			since = since.AddDate(0, 0, -7)
 			until = until.AddDate(0, 0, -7)
-		case "monthly-report":
+		case "monthly":
 			since = time.Date(since.Year(), since.Month()-1, 1, 0, 0, 0, 0, loc)
 			until = since.AddDate(0, +1, -1)
 		}

--- a/domain/usersupport/user_support_test.go
+++ b/domain/usersupport/user_support_test.go
@@ -37,6 +37,8 @@ var (
 				{Name: github.String("PF_Support")},
 				{Name: github.String("緊急度：低")},
 				{Name: github.String("CaaS-A 対応中")},
+				{Name: github.String("Escalation")},
+				{Name: github.String("genre:通常問合せ")},
 			},
 			HTMLURL: github.String("https://github.com/sataga/issue-warehouse/issues/1"),
 		},
@@ -55,6 +57,7 @@ var (
 				{Name: github.String("PF_Support")},
 				{Name: github.String("緊急度：中")},
 				{Name: github.String("CaaS-A 対応中")},
+				{Name: github.String("genre:要望")},
 			},
 			HTMLURL: github.String("https://github.com/sataga/issue-warehouse/issues/2"),
 		},
@@ -70,6 +73,7 @@ var (
 				{Name: github.String("PF_Support")},
 				{Name: github.String("緊急度：高")},
 				{Name: github.String("CaaS-A 対応中")},
+				{Name: github.String("genre:サービス障害")},
 			},
 			HTMLURL: github.String("https://github.com/sataga/issue-warehouse/issues/3"),
 		},
@@ -85,6 +89,7 @@ var (
 				{Name: github.String("PF_Support")},
 				{Name: github.String("緊急度：低")},
 				{Name: github.String("CaaS-B 対応中")},
+				{Name: github.String("genre:通常問合せ")},
 			},
 			HTMLURL: github.String("https://github.com/sataga/issue-warehouse/issues/4"),
 		},
@@ -138,6 +143,7 @@ func Test_userSupport_GetDailyReportStats(t *testing.T) {
 						TargetSpan:   fiveDayAgo.Format("2006-01-02"),
 						TeamName:     "CaaS-A",
 						Urgency:      "高",
+						Genre:        "サービス障害",
 						NumComments:  3,
 						OpenDuration: 119,
 						Escalation:   false,
@@ -150,6 +156,7 @@ func Test_userSupport_GetDailyReportStats(t *testing.T) {
 						TargetSpan:   fiveDayAgo.Format("2006-01-02"),
 						TeamName:     "CaaS-B",
 						Urgency:      "低",
+						Genre:        "通常問合せ",
 						NumComments:  4,
 						OpenDuration: 71,
 						Escalation:   false,
@@ -322,11 +329,11 @@ func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 						Span:                       startEnd,
 						NumCreatedIssues:           2,
 						NumClosedIssues:            2,
-						NumGenreNormalIssues:       0,
-						NumGenreRequestIssues:      0,
+						NumGenreNormalIssues:       1,
+						NumGenreRequestIssues:      1,
 						NumGenreFailureIssues:      0,
-						NumEscalationAllIssues:     0,
-						NumEscalationNormalIssues:  0,
+						NumEscalationAllIssues:     1,
+						NumEscalationNormalIssues:  1,
 						NumEscalationRequestIssues: 0,
 						NumEscalationFailureIssues: 0,
 						NumUrgencyHighIssues:       1,
@@ -350,9 +357,10 @@ func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 						TargetSpan:   startEnd,
 						TeamName:     "CaaS-A",
 						Urgency:      "低",
+						Genre:        "通常問合せ",
 						NumComments:  1,
 						OpenDuration: 168,
-						Escalation:   false,
+						Escalation:   true,
 					},
 					1: {
 						Title:        "issue 2",
@@ -363,6 +371,7 @@ func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 						TargetSpan:   startEnd,
 						TeamName:     "CaaS-A",
 						Urgency:      "中",
+						Genre:        "要望",
 						NumComments:  2,
 						OpenDuration: 96,
 						Escalation:   false,
@@ -433,4 +442,29 @@ func getClosedIssue(since, until time.Time, issues []*github.Issue) []*github.Is
 		}
 	}
 	return iss
+}
+
+func TestLongTermStats_GenLongTermReport(t *testing.T) {
+	type fields struct {
+		SummaryStats map[string]*SummaryStats
+		DetailStats  map[int]*DetailStats
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lts := &LongTermStats{
+				SummaryStats: tt.fields.SummaryStats,
+				DetailStats:  tt.fields.DetailStats,
+			}
+			if got := lts.GenLongTermReport(); got != tt.want {
+				t.Errorf("LongTermStats.GenLongTermReport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/domain/usersupport/user_support_test.go
+++ b/domain/usersupport/user_support_test.go
@@ -282,143 +282,6 @@ func TestDailyStats_GetDailyReportStats(t *testing.T) {
 	}
 }
 
-// func Test_userSupport_GetLongTermReportStats(t *testing.T) {
-// 	var c *gomock.Controller
-
-// 	testIssues := []*github.Issue{
-// 		issuePatterns[0],
-// 		issuePatterns[1],
-// 		issuePatterns[2],
-// 		issuePatterns[3],
-// 	}
-
-// 	type fields struct {
-// 		repo Repository
-// 	}
-// 	type args struct {
-// 		until time.Time
-// 		kind  string
-// 		span  int
-// 	}
-// 	tests := []struct {
-// 		name       string
-// 		fields     fields
-// 		args       args
-// 		want       LongTermStats
-// 		wantErr    bool
-// 		beforefunc func(f *fields, w *LongTermStats, until time.Time, kind string, span int)
-// 		afterfunc  func()
-// 	}{
-// 		// TODO: Add test cases.
-// 		{
-// 			name: "Normal operation",
-// 			args: args{
-// 				until: now,
-// 				kind:  "weekly",
-// 				span:  4,
-// 			},
-// 			wantErr: false,
-// 			beforefunc: func(f *fields, w *LongTermStats, until time.Time, kind string, span int) {
-// 				c = gomock.NewController(t)
-// 				musr := NewMockRepository(c)
-// 				var since time.Time
-// 				loc, _ := time.LoadLocation("Asia/Tokyo")
-// 				switch kind {
-// 				case "weekly":
-// 					since = until.AddDate(0, 0, -7)
-// 				case "monthly":
-// 					since = time.Date(until.Year(), until.Month(), 1, 0, 0, 0, 0, loc)
-// 					until = since.AddDate(0, +1, -1)
-// 				}
-// 				var cnt int
-// 				for i := 1; i <= span; i++ {
-// 					startEnd := fmt.Sprintf("%s~%s", since.Format("2006-01-02"), until.Format("2006-01-02"))
-// 					cri := getCreatedIssue(since, until, testIssues)
-// 					cli := getClosedIssue(since, until, testIssues)
-// 					w.SummaryStats[startEnd] = &SummaryStats{
-// 						Span:             startEnd,
-// 						NumCreatedIssues: len(cri),
-// 					}
-// 					for _, issue := range cli {
-// 						w.DetailStats[cnt] = &DetailStats{}
-// 						w.DetailStats[cnt].writeDetailStatsForTest(issue, startEnd)
-// 						cnt++
-// 					}
-
-// 					musr.EXPECT().GetCreatedSupportIssues(since, until).Return(cri, nil)
-// 					musr.EXPECT().GetClosedSupportIssues(since, until).Return(cli, nil)
-
-// 					switch kind {
-// 					case "weekly":
-// 						since = since.AddDate(0, 0, -7)
-// 						until = until.AddDate(0, 0, -7)
-// 					case "monthly":
-// 						since = time.Date(since.Year(), since.Month()-1, 1, 0, 0, 0, 0, loc)
-// 						until = since.AddDate(0, +1, -1)
-// 					}
-// 				}
-// 				f.repo = musr
-// 			},
-// 			afterfunc: func() {
-// 				c.Finish()
-// 			},
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-
-// 			tt.want = LongTermStats{
-// 				SummaryStats: make(map[string]*SummaryStats, tt.args.span),
-// 				DetailStats:  make(map[int]*DetailStats, tt.args.span),
-// 			}
-// 			if tt.beforefunc != nil {
-// 				tt.beforefunc(&tt.fields, &tt.want, tt.args.until, tt.args.kind, tt.args.span)
-// 			}
-// 			if tt.afterfunc != nil {
-// 				defer tt.afterfunc()
-// 			}
-// 			us := &userSupport{
-// 				repo: tt.fields.repo,
-// 			}
-// 			fmt.Println(tt.want.SummaryStats)
-// 			for _, ss := range tt.want.SummaryStats {
-// 				fmt.Println(ss)
-// 			}
-// 			for _, ds := range tt.want.DetailStats {
-// 				fmt.Println(ds)
-// 			}
-// 			got, err := us.GetLongTermReportStats(tt.args.until, tt.args.kind, tt.args.span)
-// 			if (err != nil) != tt.wantErr {
-// 				t.Errorf("userSupport.GetLongTermReportStats() error = %v, wantErr %v", err, tt.wantErr)
-// 				return
-// 			}
-// 			if !reflect.DeepEqual(got, tt.want) {
-// 				t.Errorf("userSupport.GetLongTermReportStats() = %v, want %v", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
-
-func getCreatedIssue(since, until time.Time, issues []*github.Issue) []*github.Issue {
-	iss := make([]*github.Issue, 0, len(issues))
-	for _, is := range issues {
-		if is.CreatedAt != nil && is.CreatedAt.After(since) && is.CreatedAt.Before(until) {
-			iss = append(iss, is)
-		}
-	}
-	return iss
-}
-
-func getClosedIssue(since, until time.Time, issues []*github.Issue) []*github.Issue {
-	iss := make([]*github.Issue, 0, len(issues))
-	for _, is := range issues {
-		if is.ClosedAt != nil && is.ClosedAt.After(since) && is.ClosedAt.Before(until) {
-			iss = append(iss, is)
-		}
-	}
-	return iss
-}
-
 func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 	var c *gomock.Controller
 
@@ -550,4 +413,24 @@ func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getCreatedIssue(since, until time.Time, issues []*github.Issue) []*github.Issue {
+	iss := make([]*github.Issue, 0, len(issues))
+	for _, is := range issues {
+		if is.CreatedAt != nil && is.CreatedAt.After(since) && is.CreatedAt.Before(until) {
+			iss = append(iss, is)
+		}
+	}
+	return iss
+}
+
+func getClosedIssue(since, until time.Time, issues []*github.Issue) []*github.Issue {
+	iss := make([]*github.Issue, 0, len(issues))
+	for _, is := range issues {
+		if is.ClosedAt != nil && is.ClosedAt.After(since) && is.ClosedAt.Before(until) {
+			iss = append(iss, is)
+		}
+	}
+	return iss
 }

--- a/domain/usersupport/user_support_test.go
+++ b/domain/usersupport/user_support_test.go
@@ -6,6 +6,7 @@ package usersupport
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -327,7 +328,7 @@ func Test_userSupport_GetLongTermReportStats(t *testing.T) {
 				SummaryStats: map[string]*SummaryStats{
 					startEnd: {
 						Span:                       startEnd,
-						NumCreatedIssues:           2,
+						NumCreatedIssues:           3,
 						NumClosedIssues:            2,
 						NumGenreNormalIssues:       1,
 						NumGenreRequestIssues:      1,
@@ -455,6 +456,90 @@ func TestLongTermStats_GenLongTermReport(t *testing.T) {
 		want   string
 	}{
 		// TODO: Add test cases.
+		{
+			name: "print monthly-report",
+			fields: fields{
+				SummaryStats: map[string]*SummaryStats{
+					startEnd: {
+						Span:                       startEnd,
+						NumCreatedIssues:           2,
+						NumClosedIssues:            2,
+						NumGenreNormalIssues:       1,
+						NumGenreRequestIssues:      1,
+						NumGenreFailureIssues:      0,
+						NumEscalationAllIssues:     1,
+						NumEscalationNormalIssues:  1,
+						NumEscalationRequestIssues: 0,
+						NumEscalationFailureIssues: 0,
+						NumUrgencyHighIssues:       1,
+						NumUrgencyLowIssues:        1,
+						NumScoreA:                  0,
+						NumScoreB:                  1,
+						NumScoreC:                  1,
+						NumScoreD:                  0,
+						NumScoreE:                  0,
+						NumScoreF:                  0,
+						NumTotalScore:              2.5,
+					},
+				},
+				DetailStats: map[int]*DetailStats{
+					0: {
+						Title:        "issue 1",
+						HTMLURL:      "https://github.com/sataga/issue-warehouse/issues/1",
+						CreatedAt:    tenDayAgo.Format("2006-01-02"),
+						ClosedAt:     threeDayAgo.Format("2006-01-02"),
+						State:        "closed",
+						TargetSpan:   startEnd,
+						TeamName:     "CaaS-A",
+						Urgency:      "低",
+						Genre:        "通常問合せ",
+						NumComments:  1,
+						OpenDuration: 168,
+						Escalation:   true,
+					},
+					1: {
+						Title:        "issue 2",
+						HTMLURL:      "https://github.com/sataga/issue-warehouse/issues/2",
+						CreatedAt:    sevenDayAgo.Format("2006-01-02"),
+						ClosedAt:     threeDayAgo.Format("2006-01-02"),
+						State:        "closed",
+						TargetSpan:   startEnd,
+						TeamName:     "CaaS-A",
+						Urgency:      "中",
+						Genre:        "要望",
+						NumComments:  2,
+						OpenDuration: 96,
+						Escalation:   false,
+					},
+				},
+			},
+			want: `## サマリー 
+|項目|startEnd|
+|----|----|
+|起票件数|2|
+|クローズ件数|2|
+|緊急度：高・中|1|
+|緊急度：低|1|
+|全体エスカレーション件数|1|
+|全体CaaS-A完結率(％)|50.0|
+|通常エスカレーション件数|1|
+|通常CaaS-A完結率(％)|50.0|
+|ジャンル:通常問合せ件数|1|
+|ジャンル:要望件数|1|
+|ジャンル:サービス障害件数|0|
+|合計スコア|2.50|
+|スコアA|0|
+|スコアB|1|
+|スコアC|1|
+|スコアD|0|
+|スコアE|0|
+|スコアF|0|
+
+## 詳細 
+- [issue 1](https://github.com/sataga/issue-warehouse/issues/1),低,通常問合せ,CaaS-A/,comment数:1,経過時間(hour):168,解決フラグ:true,(startEnd)
+- [issue 2](https://github.com/sataga/issue-warehouse/issues/2),中,要望,CaaS-A/,comment数:2,経過時間(hour):96,解決フラグ:false,(startEnd)
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -462,6 +547,7 @@ func TestLongTermStats_GenLongTermReport(t *testing.T) {
 				SummaryStats: tt.fields.SummaryStats,
 				DetailStats:  tt.fields.DetailStats,
 			}
+			tt.want = strings.Replace(tt.want, "startEnd", startEnd, -1)
 			if got := lts.GenLongTermReport(); got != tt.want {
 				t.Errorf("LongTermStats.GenLongTermReport() = %v, want %v", got, tt.want)
 			}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,6 @@ func main() {
 		cnt := 0
 		for i := 1; i <= *longtermSpanInt; i++ {
 			result, err := us.GetLongTermReportStats(since, until)
-			fmt.Println(result)
 			for key, val := range result.SummaryStats {
 				LongTermStats.SummaryStats[key] = val
 			}


### PR DESCRIPTION
> 実装から見直してテストが通るようになった

domainの中でループさせるのではなく、main.goでループさせるようにした
そうすることで、domainのテストは１通りの出力が正しいことが確認できればOKとなりで、テスト実装が楽、というかかけるようになった。

```
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Tesiting-longterm-report ± 
-> % go test -v github.com/sataga/go-github-sample/domain/usersupport                                                                                                                                                           01:41:48 - 01:41:49
=== RUN   Test_userSupport_GetDailyReportStats
=== RUN   Test_userSupport_GetDailyReportStats/since_<_until
--- PASS: Test_userSupport_GetDailyReportStats (0.00s)
    --- PASS: Test_userSupport_GetDailyReportStats/since_<_until (0.00s)
=== RUN   TestDailyStats_GetDailyReportStats
=== RUN   TestDailyStats_GetDailyReportStats/print_daily-report
--- PASS: TestDailyStats_GetDailyReportStats (0.00s)
    --- PASS: TestDailyStats_GetDailyReportStats/print_daily-report (0.00s)
=== RUN   Test_userSupport_GetLongTermReportStats
=== RUN   Test_userSupport_GetLongTermReportStats/Normal_operation_for_monthly
--- PASS: Test_userSupport_GetLongTermReportStats (0.00s)
    --- PASS: Test_userSupport_GetLongTermReportStats/Normal_operation_for_monthly (0.00s)
PASS
ok      github.com/sataga/go-github-sample/domain/usersupport   (cached)
```

普通に実行して問題ないことも確認とれた
```
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Tesiting-longterm-report 
-> % go run main.go longterm-report | pbcopy                                                                                                                                                                                    01:48:11 - 01:48:25
 t-sataga@MBA  ~/go/src/github.com/sataga/go-github-sample   Tesiting-longterm-report 
-> %          
```
## サマリー 
|項目|2020-12-01~2020-12-31|2021-01-01~2021-01-31|2021-02-01~2021-02-28|2021-03-01~2021-03-31|
|----|----|----|----|----|
|起票件数|1|0|0|0|
|クローズ件数|5|0|1|1|
|緊急度：高・中|3|0|1|0|
|緊急度：低|2|0|0|1|
|全体エスカレーション件数|2|0|0|1|
|全体CaaS-A完結率(％)|40.0|0|0|100.0|
|通常エスカレーション件数|1|0|0|0|
|通常CaaS-A完結率(％)|20.0|0|0|0|
|ジャンル:通常問合せ件数|3|0|0|0|
|ジャンル:要望件数|2|0|0|0|
|ジャンル:サービス障害件数|0|0|1|1|
|合計スコア|5.20|0.00|6.00|6.00|
|スコアA|0|0|0|0|
|スコアB|0|0|0|0|
|スコアC|0|0|0|0|
|スコアD|1|0|0|0|
|スコアE|2|0|0|0|
|スコアF|2|0|1|1|

## 詳細 
- [INC0000003 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/3),中,通常問合せ,CaaS-A/,comment数:0,経過時間(hour):483,解決フラグ:true,(2020-12-01~2020-12-31)
- [INC0000002 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/2),高,通常問合せ,CaaS-B/@sataga,comment数:2,経過時間(hour):8425,解決フラグ:false,(2020-12-01~2020-12-31)
- [INC0000001 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/1),低,要望,CaaS-A/@sataga,comment数:4,経過時間(hour):8425,解決フラグ:false,(2020-12-01~2020-12-31)
- [INC0000010 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/10),高,要望,CaaS-A/,comment数:1,経過時間(hour):455,解決フラグ:true,(2020-12-01~2020-12-31)
- [INC0000004 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/4),低,通常問合せ,CaaS-A/,comment数:1,経過時間(hour):483,解決フラグ:false,(2020-12-01~2020-12-31)
- [INC0000005 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/5),中,サービス障害,CaaS-A/@sataga,comment数:3,経過時間(hour):2040,解決フラグ:false,(2021-02-01~2021-02-28)
- [INC0000006 - Sample Issue](https://github.com/sataga/issue-warehouse/issues/6),低,サービス障害,CaaS-A/,comment数:6,経過時間(hour):2185,解決フラグ:true,(2021-03-01~2021-03-31)

